### PR TITLE
Documentation and unit test fixes

### DIFF
--- a/implement-a-planning-search/README.md
+++ b/implement-a-planning-search/README.md
@@ -137,7 +137,7 @@ After implementation of the heuristics, run the heuristic-based A* search algori
    * Heuristics:
       * `h_pg_levelsum()`
       * `h_pg_setlevel()`
-* Test the implemented methods in `PlanningGraph` by running the unit tests provided in `test_my_planning_graph.py`.  From the command line enter `python -m unittests tests.test_my_planning_graph`
+* Test the implemented methods in `PlanningGraph` by running the unit tests provided in `test_my_planning_graph.py`.  From the command line enter `python -m unittest tests.test_my_planning_graph`
 * Run A* planning searches using the three automated heuristics described above on each of the three problems.  Collect metrics on number of node expansions required, number of goal tests, time elapsed, and optimality of solution for each search algorithm for use in the written analysis.  
 * Test the Problem 3 solutions against the `acp3_pddl` definition created previously.
 * Submit the completed `my_planning_graph.py` module.

--- a/implement-a-planning-search/my_planning_graph.py
+++ b/implement-a-planning-search/my_planning_graph.py
@@ -375,15 +375,13 @@ class PlanningGraph():
 
     def inconsistent_effects_mutex(self, node_a1: PgNode_a, node_a2: PgNode_a)->bool:
         '''
-        Test a pair of state literals for mutual exclusion, returning True if
-        there are no actions that could achieve the two literals at the same
-        time, and False otherwise.  In other words, the two literal nodes are
-        mutex if all of the actions that could achieve the first literal node
-        are pairwise mutually exclusive with all of the actions that could
-        achieve the second literal node.
+        Test a pair of actions for inconsistent effects, returning True if
+        one action negates an effect of the other, and False otherwise.
 
-        HINT: The PgNode.is_mutex method can be used to test whether two nodes
-        are mutually exclusive.
+        HINT: The Action instance associated with an action node is accessible
+        through the PgNode_a.action attribute. See the Action class
+        documentation for details on accessing the effects and preconditions of
+        an action.
 
         :param node_a1: PgNode_a
         :param node_a2: PgNode_a

--- a/implement-a-planning-search/tests/test_my_planning_graph.py
+++ b/implement-a-planning-search/tests/test_my_planning_graph.py
@@ -88,6 +88,21 @@ class TestPlanningGraphMutex(unittest.TestCase):
         mutexify(self.na1, self.na2)
         self.assertTrue(PlanningGraph.inconsistent_support_mutex(self.pg, self.ns1, self.ns2),"Mutex parent actions should result in inconsistent-support mutex")
 
+        self.na6 = PgNode_a(Action(expr('Go(everywhere)'), 
+            [[],[]],[[expr('At(here)'), expr('At(there)')],[]]))
+        self.na6.children.add(self.ns1)
+        self.ns1.parents.add(self.na6)
+        self.na6.children.add(self.ns2)
+        self.ns2.parents.add(self.na6)
+        self.na6.parents.add(self.ns3)
+        self.na6.parents.add(self.ns4)
+        mutexify(self.na1, self.na6)
+        mutexify(self.na2, self.na6)
+        self.assertFalse(PlanningGraph.inconsistent_support_mutex(
+            self.pg, self.ns1, self.ns2),
+            "If one parent action can achieve both states, should NOT be inconsistent-support mutex, even if parent actions are themselves mutex")
+
+
 class TestPlanningGraphHeuristics(unittest.TestCase):
     def setUp(self):
         self.p = have_cake()

--- a/implement-a-planning-search/tests/test_my_planning_graph.py
+++ b/implement-a-planning-search/tests/test_my_planning_graph.py
@@ -71,6 +71,7 @@ class TestPlanningGraphMutex(unittest.TestCase):
 
     def test_interference_mutex(self):
         self.assertTrue(PlanningGraph.interference_mutex(self.pg, self.na4, self.na5), "Precondition from one node opposite of effect of other node should be mutex")
+        self.assertTrue(PlanningGraph.interference_mutex(self.pg, self.na5, self.na4), "Precondition from one node opposite of effect of other node should be mutex")
         self.assertFalse(PlanningGraph.interference_mutex(self.pg, self.na1, self.na2), "Non-interfering incorrectly marked mutex")
 
     def test_competing_needs_mutex(self):


### PR DESCRIPTION
@cgearhart and @danainschool : These commits fix four errors that may affect students.

1. The instructions for Problem 3 of the planning project included a broken command for running unit tests.
2. The description inside inconsistent_effects_mutex incorrectly described a different mutex condition. 
3. The unit tests for interference_mutex were incomplete and would pass some incorrect implementations.
4. The unit tests for inconsistent_support_mutex were incomplete and would pass some incorrect implementations.

Note for #2 above, the hint I suggested refers to the Action object just to make it consistent with the comment in interference_mutex, but I'm not convinced either of those are good hints.