### PR TITLE
Fix assert solver check should equal to sat

### DIFF
--- a/Exercises/1_Constraint Satisfaction/AIND-Constraint_Satisfaction.ipynb
+++ b/Exercises/1_Constraint Satisfaction/AIND-Constraint_Satisfaction.ipynb
@@ -321,7 +321,7 @@
     "for N in sizes:\n",
     "    nq_solver = nqueens(N)\n",
     "    start = time.perf_counter()\n",
-    "    assert nq_solver.check(), \"Uh oh...The solver failed to find a solution. Check your constraints.\"\n",
+    "    assert nq_solver.check() == sat, \"Uh oh...The solver failed to find a solution. Check your constraints.\"\n",
     "    end = time.perf_counter()\n",
     "    print(\"{}-queens: {}ms\".format(N, (end-start) * 1000))\n",
     "    runtimes.append((end - start) * 1000)\n",


### PR DESCRIPTION
Currently it is asserting  solver.check(), which is always True, no matter the solver found a solution (sat) or not (unsat)