### PR TITLE
Update collections import for compatibility with newer Python versions

### DIFF
--- a/Projects/2_Classical Planning/layers.py
+++ b/Projects/2_Classical Planning/layers.py
@@ -2,8 +2,12 @@
 from copy import deepcopy
 from functools import lru_cache
 from itertools import combinations
-from collections import defaultdict, MutableSet
-
+try:
+    from collections import defaultdict, MutableSet
+except ImportError:
+    from collections.abc import MutableSet
+    from collections import defaultdict
+    
 from aimacode.planning import Action
 from aimacode.utils import expr, Expr
 


### PR DESCRIPTION
This PR updates the import statements for defaultdict and MutableSet to ensure compatibility with newer versions of Python. 
In newer Python versions, MutableSet has been moved from collections to collections.abc. 
The updated import statements now handle this change by using a try-except block to maintain compatibility with both older and newer versions of Python.